### PR TITLE
linkcheck tweaks

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -35,7 +35,6 @@ jobs:
           args: "--verbose \
                  --cache \
                  --max-cache-age 1d \
-                 --exclude-mail \
                  'result/**/*.md' 'result/**/*.html'"
           fail: true
         env:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,2 @@
 https://twitter\.com/.*
+https://nexus\.ironrealms\.com/GMCP

--- a/linkcheck.sh
+++ b/linkcheck.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-lychee --verbose --exclude-mail 'result/**/*.md' 'result/**/*.html'
+lychee --verbose 'result/**/*.md' 'result/**/*.html'


### PR DESCRIPTION
* `--exclude-mail` is now the default, requiring opting in to checking mail addrs.
* `https://nexus.ironrealms.com/gmcp` seems to be giving errors from the GitHub runner network perspective I can't repro locally. Ignore it for now.